### PR TITLE
Adding iOS support for kotlin multiplatform mobile apps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
     ios {
         binaries {
             framework {
-                baseName = "MultiplatformExpressionsEvaluator"
+                baseName = "ExpressionsEvaluator"
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,13 @@ kotlin {
             }
         }
     }
+    ios {
+        binaries {
+            framework {
+                baseName = "MultiplatformExpressionsEvaluator"
+            }
+        }
+    }
     val hostOs = System.getProperty("os.name")
     val isMingwX64 = hostOs.startsWith("Windows")
     val nativeTarget = when {


### PR DESCRIPTION
Hi @murzagalin!

I’m developing a kotlin multiplatform mobile app for Android and iOS and would like to use your library. Unfortunately, the multiplatform-expression-evaluator does not support iOS targets. 

That’s why I created this pull request, which adds the iOS support to the library. I tested the PR with my app and successfully executed the expression parser on both platforms: Android and iOS.

Thanks for your feedback!